### PR TITLE
Fix `validate_certs` not used issue.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ codeaffen.phpipam Release Notes
 .. contents:: Topics
 
 
+v1.1.1
+======
+
+Bugfixes
+--------
+
+- Fix `validate_certs` is not used for api connection (https://github.com/codeaffen/phpipam-ansible-modules/issues/27)
+
 v1.1.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -51,3 +51,10 @@ releases:
     fragments:
     - missing_validate_certs_parameter.yml
     release_date: '2020-11-12'
+  1.1.1:
+    changes:
+      bugfixes:
+      - Fix `validate_certs` is not used for api connection (https://github.com/codeaffen/phpipam-ansible-modules/issues/27)
+    fragments:
+    - fix_validate_certs_not_used.yml
+    release_date: '2020-11-12'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -3,7 +3,7 @@ name: "phpipam"
 description: Ansible Modules to manage phpIPAM installations
 authors:
   - "Christian Meißner <cme+ansible@meissner.sh>"
-version: "1.1.0"
+version: "1.1.1"
 license:
   - "GPL-3.0-or-later"
 tags:

--- a/plugins/module_utils/phpipam_helper.py
+++ b/plugins/module_utils/phpipam_helper.py
@@ -82,7 +82,7 @@ class PhpipamAnsibleModule(AnsibleModule):
         self._phpipamapi_app_id = self.phpipam_params.get('app_id')
         self._phpipamapi_username = self.phpipam_params.get('username')
         self._phpipamapi_password = self.phpipam_params.get('password')
-        self._phpipamapi_ssl_verify = self.phpipam_params.get('ssl_verify', True)
+        self._phpipamapi_validate_certs = self.phpipam_params.get('validate_certs', True)
         self._phpipamapi_path = kwargs.get('phpipam_path')
         self._phpipamapi_params = kwargs.get('phpipam_params')
 
@@ -116,7 +116,7 @@ class PhpipamAnsibleModule(AnsibleModule):
             app_id=self._phpipamapi_app_id,
             username=self._phpipamapi_username,
             password=self._phpipamapi_password,
-            ssl_verify=self._phpipamapi_ssl_verify,
+            ssl_verify=self._phpipamapi_validate_certs,
             user_agent="phpipam-ansible-modules",
         )
 

--- a/tests/test_playbooks/tasks/section.yml
+++ b/tests/test_playbooks/tasks/section.yml
@@ -16,5 +16,5 @@
     show_vrf: "{{ section_show_vrf | default(omit) }}"
     show_supernets_only: "{{ section_show_supernets_only | default(omit) }}"
     dns_resolver: "{{ section_dns_resolver | default(omit) }}"
-    validate_certs: "{{ section_validate_certs | default(omit) }}"
+    validate_certs: "{{ section_validate_certs | default('no') }}"
     state: "{{ section_state | default('present') }}"


### PR DESCRIPTION
Fix #27. Now a provided `validate_certs` parameter is used in api
connection.