### PR TITLE
Fix address tag resolution

### DIFF
--- a/changelogs/fragments/fix-tag-lookups.yml
+++ b/changelogs/fragments/fix-tag-lookups.yml
@@ -1,0 +1,2 @@
+bug_fixes:
+  - Fix tag lookups when specified in an `address` task (https://github.com/codeaffen/phpipam-ansible-modules/issues/57)

--- a/plugins/module_utils/phpipam_helper.py
+++ b/plugins/module_utils/phpipam_helper.py
@@ -214,6 +214,8 @@ class PhpipamAnsibleModule(AnsibleModule):
             result = self.find_subnet(subnet, mask, self.phpipam_params['section'])
         elif controller == 'tools/device_types':
             result = self.find_device_type(self.phpipam_params[key])
+        elif controller == 'tools/tags':
+            result = self.find_by_key(controller=controller, value=self.phpipam_params[key], key='type')
         elif 'tools' in controller or controller in ['vlan', 'l2domains', 'vrf']:
             result = self.find_by_key(controller=controller, value=self.phpipam_params[key])
         else:


### PR DESCRIPTION
Tags returned from the API do not have a 'tag' attribute—the tag value is returned in the 'type' attribute.

This introduces a special case for tag lookups to allow the `filter_by` value to be overridden.