### PR TITLE
Build toolset for automated testing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
 ansible
+ansible_runner<2.0; python_version < '3.6'
+ansible_runner; python_version >= '3.6'
 wheel
 jinja2 # pyup: ignore
 PyYAML~=5.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,108 @@
+import json
+import os
+
+import ansible_runner
+import pkg_resources
+import pytest
+import py.path  # type: ignore
+import yaml
+
+
+TEST_PLAYBOOKS_PATH = py.path.local(__file__).realpath() / '..' / 'test_playbooks'
+
+
+def find_all_test_playbooks():
+    for playbook in TEST_PLAYBOOKS_PATH.listdir(sort=True):
+        playbook = playbook.basename
+        if playbook.endswith('.yml'):
+            yield playbook.replace('.yml', '')
+
+
+TEST_PLAYBOOKS = list(find_all_test_playbooks())
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--vcrmode",
+        action="store",
+        default="replay",
+        choices=["replay", "record", "live"],
+        help="mode for vcr recording; one of ['replay', 'record', 'live']",
+    )
+
+
+@pytest.fixture
+def vcrmode(request):
+    return request.config.getoption("vcrmode")
+
+
+def get_phpipam_url():
+    server_yml = py.path.local(__file__).realpath() / '..' / 'test_playbooks/vars/server.yml'
+    with open(server_yml.strpath) as server_yml_file:
+        server_yml_content = yaml.safe_load(server_yml_file)
+
+    return server_yml_content['phpipam_server_url']
+
+
+def run_playbook(module, extra_vars=None, limit=None, inventory=None, check_mode=False, extra_env=None):
+    # Assemble parameters for playbook call
+    os.environ['ANSIBLE_CONFIG'] = os.path.join(os.getcwd(), 'ansible.cfg')
+    if extra_env is not None:
+        os.environ.update(extra_env)
+    kwargs = {}
+    kwargs['playbook'] = os.path.join(os.getcwd(), 'tests', 'test_playbooks', '{}.yml'.format(module))
+    if inventory is None:
+        inventory = os.path.join(os.getcwd(), 'tests', 'inventory', 'hosts')
+    kwargs['inventory'] = inventory
+    kwargs['verbosity'] = 4
+    if extra_vars:
+        kwargs['extravars'] = extra_vars
+    if limit:
+        kwargs['limit'] = limit
+    if check_mode:
+        kwargs['cmdline'] = "--check"
+    return ansible_runner.run(**kwargs)
+
+
+def run_playbook_vcr(tmpdir, module, extra_vars=None, limit=None, inventory=None, record=False, check_mode=False, extra_env=None):
+    if extra_vars is None:
+        extra_vars = {}
+    if extra_env is None:
+        extra_env = {}
+    if record:
+        # Cassettes that are to be overwritten must be deleted first
+        record_mode = 'once'
+        extra_vars['recording'] = True
+    else:
+        # Never reach out to the internet
+        record_mode = 'none'
+        if limit is None:
+            # Only run the tests (skip fixtures)
+            limit = 'tests:container'
+
+    # Dump recording parameters to json-file and pass its name by environment
+    test_params = {'test_name': module, 'serial': 0, 'record_mode': record_mode, 'check_mode': check_mode}
+    params_file = tmpdir.join('{}_test_params.json'.format(module))
+    params_file.write(json.dumps(test_params), ensure=True)
+
+    # cache_dir = tmpdir.join('cache')
+    # cache_dir.ensure(dir=True)
+    # apypie_cache_folder = get_phpipam_url().replace(':', '_').replace('/', '_')
+    # json_cache = cache_dir / 'apypie' / apypie_cache_folder / 'v2/default.json'
+    # json_cache.ensure()
+    # json_cache = cache_dir
+    # apidoc = 'apidoc/{}.json'.format(module)
+    # fixture_dir = py.path.local(__file__).realpath() / '..' / 'fixtures'
+    # fixture_dir.join(apidoc).copy(json_cache)
+
+    return run_playbook(module, extra_vars=extra_vars, limit=limit, inventory=inventory, check_mode=check_mode, extra_env=extra_env)
+
+
+def get_ansible_version():
+    ansible_version = None
+    for ansible_name in ['ansible', 'ansible-base', 'ansible-core']:
+        try:
+            ansible_version = pkg_resources.get_distribution(ansible_name).version
+        except pkg_resources.DistributionNotFound:
+            pass
+    return ansible_version

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,11 +1,9 @@
-import distutils.version
 import os
 import sys
-from ansible_runner.utils import isinventory
 
 import pytest
 
-from .conftest import TEST_PLAYBOOKS, run_playbook, run_playbook_vcr, get_ansible_version
+from .conftest import TEST_PLAYBOOKS, run_playbook, run_playbook_vcr
 
 IGNORED_WARNINGS = [
     "Activation Key 'Test Activation Key Copy' already exists.",

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -1,0 +1,49 @@
+import distutils.version
+import os
+import sys
+from ansible_runner.utils import isinventory
+
+import pytest
+
+from .conftest import TEST_PLAYBOOKS, run_playbook, run_playbook_vcr, get_ansible_version
+
+IGNORED_WARNINGS = [
+    "Activation Key 'Test Activation Key Copy' already exists.",
+]
+
+if sys.version_info[0] == 2:
+    for envvar in os.environ.keys():
+        try:
+            os.environ[envvar] = os.environ[envvar].decode('utf-8').encode('ascii', 'ignore')
+        except UnicodeError:
+            os.environ.pop(envvar)
+
+
+@pytest.mark.parametrize('module', TEST_PLAYBOOKS)
+def test_crud(tmpdir, module, vcrmode):
+    if vcrmode == "live":
+        run = run_playbook(module)
+    else:
+        record = vcrmode == "record"
+        run = run_playbook_vcr(tmpdir, module, record=record)
+    assert run.rc == 0
+
+    _assert_no_warnings(run)
+
+
+@pytest.mark.parametrize('module', TEST_PLAYBOOKS)
+def test_check_mode(tmpdir, module):
+    run = run_playbook_vcr(tmpdir, module, check_mode=True)
+    assert run.rc == 0
+
+    _assert_no_warnings(run)
+
+
+def _assert_no_warnings(run):
+    for event in run.events:
+        # check for play level warnings
+        assert not event.get('event_data', {}).get('warning', False)
+
+        # check for task level warnings
+        event_warnings = [warning for warning in event.get('event_data', {}).get('res', {}).get('warnings', []) if warning not in IGNORED_WARNINGS]
+        assert [] == event_warnings, str(event_warnings)


### PR DESCRIPTION
Get `crud_test.py` and `conftest.py` from
theforeman/foreman-ansible-modules repo.
Try to adapt both for this repo.
Commented apipie specific stuff.
Wrapper works now for `live` and `record` but without saving fixtures.
It needs to be investigated what I miss here and make `record` mode work
properly.