### PR TITLE
Provide testing facilities

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,74 @@
+name: "Test Collection"
+on: push
+
+jobs:
+  test:
+    name: run tests
+    runs-on: ubuntu-latest
+    services:
+      database:
+        image: mariadb:10.3.18
+        ports:
+          - "3306:3306"
+        env:
+          MYSQL_ROOT_PASSWORD: "rootpw"
+          MYSQL_USER: "phpipam"
+          MYSQL_PASSWORD: "phpipamadmin"
+          MYSQL_DATABASE: "phpipam"
+      phpipam:
+        image: phpipam/phpipam-www:v1.4.4
+        ports:
+          - "443:443"
+        env:
+          IPAM_DATABASE_HOST: "database"
+          IPAM_DATABASE_USER: "phpipam"
+          IPAM_DATABASE_PASS: "phpipamadmin"
+          IPAM_DATABASE_NAME: "phpipam"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Checkout phpipam repo
+        uses: actions/checkout@v2
+        with:
+          repository: phpipam/phpipam
+          ref: v1.4.4
+          path: phpipam
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: setup test environment
+        run: |
+          make test-setup
+        env:
+          PHPIPAM_URL: "https://localhost"
+          PHPIPAM_APPID: "ansible"
+          PHPIPAM_USERNAME: "admin"
+          PHPIPAM_PASSWORD: "ipamadmin"
+      # - name: "waiting for database to come online"
+      #   run: |
+      #     for i in `seq 1 10`;
+      #     do
+      #       nc -z 127.0.0.1 3306 && echo Success && exit 0
+      #       echo -n .
+      #       sleep 1
+      #     done
+      #     echo Failed waiting for MySQL && exit 1
+      - name: load data into database
+        run: |
+          mysql -h 127.0.0.1 -u phpipam -pphpipamadmin phpipam < phpipam/db/SCHEMA.sql
+      - name: activate api
+        run: |
+          mysql -h 127.0.0.1 -u phpipam -pphpipamadmin phpipam --execute="UPDATE settings SET api=1 WHERE id=1;"
+      - name: add api key for tests
+        run: |
+          mysql -h 127.0.0.1 -u phpipam -pphpipamadmin phpipam --execute="INSERT INTO api (app_id, app_code, app_permissions, app_security, app_lock_wait) VALUES ('ansible','aAbBcCdDeEfF00112233445566778899',2,'ssl_token',0);"
+      - name: run single test
+        run: |
+          make test-example_setup
+        env:
+          PHPIPAM_VALIDATE_CERTS: false
+      - name: run tests
+        run: |
+          make test-all
+        env:
+          PHPIPAM_VALIDATE_CERTS: "false"

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,8 @@ clean:
 	find . -name '*~' -exec rm -f {} +
 	find . -name '__pycache__' -exec rm -rf {} +
 	find . -name '*.tar.gz' -delete
+	docker-compose -f docker/docker-compose.yml stop
+	docker-compose -f docker/docker-compose.yml rm --force
 
 doc-setup:
 	pip install -r docs/requirements.txt
@@ -88,6 +90,11 @@ tests/test_playbooks/vars/server.yml:
 
 install-deps:
 	pip install -r requirements-dev.txt
+
+setup-phpipam: test-setup
+	docker-compose -f docker/docker-compose.yml up -d
+	sleep 30
+	docker/setup_database.sh
 
 FORCE:
 

--- a/changelogs/fragments/add_automatic_testing_facility.yml
+++ b/changelogs/fragments/add_automatic_testing_facility.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fix \#68 - add automatic testing facility for all modules

--- a/changelogs/fragments/provide_local_phpiapm_environment.yml
+++ b/changelogs/fragments/provide_local_phpiapm_environment.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fix \#69 - add facility to setup local phpipam environment

--- a/changelogs/fragments/support_command_line_parameters.yml
+++ b/changelogs/fragments/support_command_line_parameters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fix \#70 - provide environment variable support for connection data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,8 +1,22 @@
 version: '3'
 services:
-  phpIPAM-www:
-    image: phpipam/phpipam-www
+  phpipam:
+    image: phpipam/phpipam-www:v1.4.4
     ports:
-      - "8080:80"
-  phpIPAM-DB:
-    image: "mysql"
+      - "443:443"
+    environment:
+      IPAM_DATABASE_HOST: "database"
+      IPAM_DATABASE_USER: "phpipam"
+      IPAM_DATABASE_PASS: "phpipamadmin"
+      IPAM_DATABASE_NAME: "phpipam"
+    depends_on:
+      - database
+  database:
+    image: mariadb:10.3.18
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: "rootpw"
+      MYSQL_USER: "phpipam"
+      MYSQL_PASSWORD: "phpipamadmin"
+      MYSQL_DATABASE: "phpipam"

--- a/docker/setup_database.sh
+++ b/docker/setup_database.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+while ! nc -z ${DB_HOST:-127.0.0.1} ${DB_PORT:-3306}; do
+  echo "Waiting for database connection..."
+  sleep 1
+done
+
+echo "Database is up"
+
+echo "Creating database ${DB_NAME:-phpipam}"
+docker exec -ti docker_phpipam_1 sh -c 'mysql -h database -u phpipam -pphpipamadmin phpipam < /phpipam/db/SCHEMA.sql'
+
+echo "Activating API"
+mysql -u phpipam -pphpipamadmin -h ${DB_HOST:-127.0.0.1} phpipam --execute="UPDATE settings SET api=1 WHERE id=1;"
+
+echo "Inserting API application"
+mysql -u phpipam -pphpipamadmin -h ${DB_HOST:-127.0.0.1} phpipam --execute="INSERT INTO api (app_id, app_code, app_permissions, app_security, app_lock_wait) VALUES ('ansible','aAbBcCdDeEfF00112233445566778899',2,'ssl_token',0);"

--- a/plugins/module_utils/phpipam_helper.py
+++ b/plugins/module_utils/phpipam_helper.py
@@ -23,7 +23,7 @@ except ImportError:
 
 from collections import defaultdict
 
-from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib, env_fallback
 
 
 class PhpipamAnsibleException(Exception):
@@ -57,11 +57,11 @@ class PhpipamAnsibleModule(AnsibleModule):
 
         self.phpipam_spec, gen_args = self._phpipam_spec_helper(kwargs.pop('phpipam_spec', {}))
         argument_spec = dict(
-            server_url=dict(required=True),
-            app_id=dict(required=True),
-            username=dict(required=True),
-            password=dict(required=True, no_log=True),
-            validate_certs=dict(type='bool', required=False, default=True),
+            server_url=dict(required=True, fallback=(env_fallback, ['PHPIPAM_SERVER_URL'])),
+            app_id=dict(required=True, fallback=(env_fallback, ['PHPIPAM_APP_ID'])),
+            username=dict(required=True, fallback=(env_fallback, ['PHPIPAM_USERNAME'])),
+            password=dict(required=True, fallback=(env_fallback, ['PHPIPAM_PASSWORD']), no_log=True),
+            validate_certs=dict(type='bool', fallback=(env_fallback, ['PHPIPAM_VALIDATE_CERTS']), required=False, default=True),
         )
         argument_spec.update(gen_args)
         argument_spec.update(kwargs.pop('argument_spec', {}))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,9 @@
 ansible
 ansible_runner<2.0; python_version < '3.6'
 ansible_runner; python_version >= '3.6'
+colour
 coverage
+geopy
 wheel
 jinja2 # pyup: ignore
 PyYAML~=5.3

--- a/tests/test_playbooks/location.yml
+++ b/tests/test_playbooks/location.yml
@@ -24,7 +24,7 @@
       vars:
         name: update location
         override:
-          address: "Alexander Platz, Berlin, Germany"
+          address: "Alexanderstraße. 1, 10115 Berlin, Deutschland"
           latitude: "{{ omit }}"
           longitude: "{{ omit }}"
         location: "{{ base_location_data | combine(override) }}"

--- a/tests/test_playbooks/vars/address.yml
+++ b/tests/test_playbooks/vars/address.yml
@@ -1,6 +1,6 @@
 ---
 base_address_data:
-  ipaddress: 172.16.0.1
-  subnet: 172.16.0.0/24
+  ipaddress: 10.65.22.1
+  subnet: 10.65.22.0/24
   section: Customers
   is_gateway: yes


### PR DESCRIPTION
* Add github workflow

  Here we spin up two service containers (db and phpipam).
  Load database schema into it.
  Activate API and add API application to use API.
  The test-setup target will be called before running tests against the
  created phpipam environment.

* Change some test data

  As the subnet for address tests does not exists the test will fail on a
  fresh phpipam installation. So we switched to a subnet that already
  exists.
  Provide valid postal address for update location test.

* Add command line parameters for connection data

  We add command line parameter parsing for connection data. So it is
  possible to override data e.g. cert validation with command line
  variables.

* Provide local phpipam enviroment

  With this change we provide a facility to setup a local phpipam setup
  based on docker-compose. If it is up and running tests can run against
  this installation.