### PR TITLE
Fix #90 - booleans in subnet module aren't working 

### DIFF
--- a/changelogs/fragments/ booleans_in_subnet_module_not_working.yml
+++ b/changelogs/fragments/ booleans_in_subnet_module_not_working.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - fix \#90 - booleans in subnet module aren't working

--- a/plugins/module_utils/phpipam_helper.py
+++ b/plugins/module_utils/phpipam_helper.py
@@ -341,7 +341,7 @@ class PhpipamAnsibleModule(AnsibleModule):
             ansible_invisible = value.get('invisible', False)
 
             if 'phpipam_name' not in phpipam_value and '_' in key:
-                phpipam_value['phpipam_name'] = inflection.camelize(key)
+                phpipam_value['phpipam_name'] = inflection.camelize(key, uppercase_first_letter=False)
 
             if phpipam_type == 'entity':
                 argument_value['type'] = 'str'

--- a/tests/test_playbooks/subnet.yml
+++ b/tests/test_playbooks/subnet.yml
@@ -19,6 +19,21 @@
         name: create subnet again, no change
         subnet: "{{ base_subnet_data }}"
 
+    - name: set booleans
+      include: tasks/subnet.yml
+      vars:
+        name: set booleans
+        override:
+          show_as_name: Yes
+          dns_recursive: Yes
+          dns_records: Yes
+          allow_requests: Yes
+          ping_subnet: Yes
+          discover_subnet: Yes
+          is_folder: Yes
+          is_full: Yes
+        subnet: "{{ base_subnet_data | combine(override) }}"
+
     - name: delete subnet
       include: tasks/subnet.yml
       vars:

--- a/tests/test_playbooks/subnet.yml
+++ b/tests/test_playbooks/subnet.yml
@@ -30,8 +30,8 @@
           allow_requests: Yes
           ping_subnet: Yes
           discover_subnet: Yes
-          is_folder: Yes
-          is_full: Yes
+          is_folder: No
+          is_full: No
         subnet: "{{ base_subnet_data | combine(override) }}"
 
     - name: delete subnet


### PR DESCRIPTION
Parameter names that do not have a `phpipam_name` parameter where camelized. `inflection.camelized()` start strings by default with a uppercase letter. This behavior needs to be adapted as camelized parameters in API calls often start with lowercase letter. 
We also add a extra test step into the subnet test case