### PR TITLE
Bugfix #98 - fix show_supernets_only parameter

### DIFF
--- a/changelogs/fragments/fix_show_supernets_only_param.yml
+++ b/changelogs/fragments/fix_show_supernets_only_param.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix \#98 - fix show_supernets_only parameter

--- a/plugins/modules/section.py
+++ b/plugins/modules/section.py
@@ -129,7 +129,7 @@ def main():
             list_order=dict(type='bool', required=False, phpipam_name='order'),
             show_vlan=dict(type='bool', required=False, phpipam_name='showVLAN'),
             show_vrf=dict(type='bool', required=False, phpipam_name='showVRF'),
-            show_supernets_only=dict(type='bool', required=False),
+            show_supernets_only=dict(type='bool', required=False, phpipam_name='showSupernetOnly'),
             dns_resolver=dict(type='entity', controller='tools/nameservers', required=False, phpipam_name='DNS'),
         )
     )

--- a/tests/test_playbooks/vars/section.yml
+++ b/tests/test_playbooks/vars/section.yml
@@ -1,6 +1,7 @@
 ---
 base_section_data:
   name: "Example Inc."
+  show_supernets_only: yes
 
 sections:
   - name: "ACME Inc."


### PR DESCRIPTION
Add `phpipam_name` to `show_supernets_only` parameter to solve mixtures
of singular and plural in api again.
Add `show_supernets_only` to section test playbook.
Add changelog entry