### PR TITLE
Add subnet parent test

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ coverage
 geopy
 wheel
 jinja2 # pyup: ignore
-PyYAML~=5.3
+PyYAML~=6.0
 cryptography
 packaging
 requests

--- a/tests/test_playbooks/subnet_parent.yml
+++ b/tests/test_playbooks/subnet_parent.yml
@@ -1,0 +1,36 @@
+---
+- name: Subnet module tests for subnets with parents/children
+  hosts: localhost
+  collections:
+    - codeaffen.phpipam
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+    - vars/subnet.yml
+  tasks:
+    - name: Create parent/children subnets
+      ansible.builtin.include_tasks: tasks/subnet.yml
+      vars:
+        name: "create subnet '{{ subnet.cidr }}'"
+      loop: "{{ subnet_parents }}"
+      loop_control:
+        loop_var: subnet
+
+    - name: Create parent/children subnets again, no change
+      ansible.builtin.include_tasks: tasks/subnet.yml
+      vars:
+        name: "create subnet '{{ subnet.cidr }}' again, no change"
+      loop: "{{ subnet_parents }}"
+      loop_control:
+        loop_var: subnet
+
+    - name: Delete parent/childre subnets
+      ansible.builtin.include_tasks: tasks/subnet.yml
+      vars:
+        name: delete subnet '{{ subent_loop.cidr }}' again, no change
+        override:
+          state: absent
+        subnet: "{{ subnet_loop | combine(override) }}"
+      loop: "{{ subnet_parents }}"
+      loop_control:
+        loop_var: subnet_loop

--- a/tests/test_playbooks/tasks/subnet.yml
+++ b/tests/test_playbooks/tasks/subnet.yml
@@ -14,7 +14,7 @@
     vlan: "{{ subnet.vlan | default(omit) }}"
     routing_domain: "{{ subnet.routing_domain | default(omit) }}"
     vrf: "{{ subnet.vrf | default(omit) }}"
-    master_subnet.cidr: "{{ subnet.master_subnet.cidr | default(omit) }}"
+    parent: "{{ subnet.parent | default(omit) }}"
     nameserver: "{{ subnet.nameserver | default(omit) }}"
     show_as_name: "{{ subnet.show_as_name | default(omit) }}"
     permissions: "{{ subnet.permissions | default(omit) }}"

--- a/tests/test_playbooks/vars/subnet.yml
+++ b/tests/test_playbooks/vars/subnet.yml
@@ -11,3 +11,13 @@ subnets:
     section: "DevOps Department"
   - cidr: 192.0.2.0/25
     section: "Infrastructure Department"
+
+subnet_parents:
+  - cidr: 172.16.0.0/20
+    section: "Customers"
+  - cidr: 172.16.0.0/24
+    section: "Customers"
+    parent: 172.16.0.0/20
+  - cidr: 172.16.1.0/24
+    section: "Customers"
+    parent: 172.16.0.0/20


### PR DESCRIPTION
As there is some work needed in managing subnets and/or folders and its
parents a test case is needed.
For that purpose we added a test playbook and a needed variable for
example data.
We also fix a bug in the `subnet` task to.
With all these changes/additions we can test subenets and parent subnets
first. In later steps we need to extend the test to also check the
majority of all combinations of subnets, folders and parents.