### PR TITLE
Refactor subnet module to handle folders

### DIFF
--- a/changelogs/fragments/feature_subnet_folder_parent.yml
+++ b/changelogs/fragments/feature_subnet_folder_parent.yml
@@ -1,0 +1,2 @@
+enhancements:
+  - Refactore `subnet` module to handle subnets in folders

--- a/docs/plugins/subnet_module.rst
+++ b/docs/plugins/subnet_module.rst
@@ -380,21 +380,21 @@ Parameters
   * - .. raw:: html
 
         <div class="ansible-option-cell">
-        <div class="ansibleOptionAnchor" id="parameter-is_folder"></div>
+        <div class="ansibleOptionAnchor" id="parameter-folder"></div>
 
-      .. _ansible_collections.codeaffen.phpipam.subnet_module__parameter-is_folder:
+      .. _ansible_collections.codeaffen.phpipam.subnet_module__parameter-folder:
 
       .. rst-class:: ansible-option-title
 
-      **is_folder**
+      **folder**
 
       .. raw:: html
 
-        <a class="ansibleOptionLink" href="#parameter-is_folder" title="Permalink to this option"></a>
+        <a class="ansibleOptionLink" href="#parameter-folder" title="Permalink to this option"></a>
 
       .. rst-class:: ansible-option-type-line
 
-      :ansible-option-type:`boolean`
+      :ansible-option-type:`string`
 
       .. raw:: html
 
@@ -404,17 +404,8 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Controls if we are adding subnet or folder
+      folder name which subnet belongs to
 
-      can't be changed after subnet was created
-
-
-      .. rst-class:: ansible-option-line
-
-      :ansible-option-choices:`Choices:`
-
-      - :ansible-option-default-bold:`no` :ansible-option-default:`← (default)`
-      - :ansible-option-choices-entry:`yes`
 
       .. raw:: html
 

--- a/plugins/modules/subnet.py
+++ b/plugins/modules/subnet.py
@@ -80,6 +80,10 @@ options:
         required: false
         aliases:
             - master_subnet_cidr
+    folder:
+        description: folder name which subnet belongs to
+        type: str
+        required: false
     nameserver:
         description: Name of the DNS server which should attach to subnet
         type: str
@@ -120,13 +124,6 @@ options:
         default: no
     discover_subnet:
         description: Controls if new hosts should be discovered for new host scans
-        type: bool
-        required: false
-        default: no
-    is_folder:
-        description:
-            - Controls if we are adding subnet or folder
-            - can't be changed after subnet was created
         type: bool
         required: false
         default: no
@@ -212,6 +209,7 @@ def main():
             routing_domain=dict(type='str', api_invisible=True, default='default'),
             vrf=dict(type='entity', controller='vrf', phpipam_name='vrfId'),
             parent=dict(type='entity', phpipam_name='masterSubnetId'),
+            folder=dict(type='entity', controller='folders', phpipam_name='masterSubnetId'),
             nameserver=dict(type='entity', controller='tools/nameservers', phpipam_name='nameserverId'),
             show_as_name=dict(type='bool', phpipam_name='showName'),
             permissions=dict(type='json'),
@@ -227,7 +225,7 @@ def main():
             threshold=dict(type='int'),
             location=dict(type='entity', controller='tools/locations'),
         ),
-        mutually_exclusive=['cidr', 'subnet'],
+        mutually_exclusive=[['cidr', 'subnet'], ['parent', 'folder']],
         required_together=[['subnet', 'mask']],
     )
 

--- a/tests/test_playbooks/folder_parent.yml
+++ b/tests/test_playbooks/folder_parent.yml
@@ -27,7 +27,7 @@
     - name: Delete parent/childre folders
       ansible.builtin.include_tasks: tasks/folder.yml
       vars:
-        name: delete folder '{{ subent_loop.cidr }}' again, no change
+        name: delete folder '{{ subent_loop.cidr }}'
         override:
           state: absent
         folder: "{{ folder_loop | combine(override) }}"

--- a/tests/test_playbooks/subnet_parent.yml
+++ b/tests/test_playbooks/subnet_parent.yml
@@ -27,7 +27,7 @@
     - name: Delete parent/childre subnets
       ansible.builtin.include_tasks: tasks/subnet.yml
       vars:
-        name: delete subnet '{{ subent_loop.cidr }}' again, no change
+        name: delete subnet '{{ subent_loop.cidr }}'
         override:
           state: absent
         subnet: "{{ subnet_loop | combine(override) }}"

--- a/tests/test_playbooks/subnet_parent_folder.yml
+++ b/tests/test_playbooks/subnet_parent_folder.yml
@@ -1,0 +1,67 @@
+---
+- name: Subnet and folder module tests
+  hosts: localhost
+  collections:
+    - codeaffen.phpipam
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+    - vars/subnet.yml
+  tasks:
+    - name: Create entities
+      block:
+        - name: Create folder
+          ansible.builtin.include_tasks: tasks/folder.yml
+          vars:
+            name: "create folder '{{ subnet_folder_data.folder }}'"
+            folder:
+              name: "{{ subnet_folder_data.folder }}"
+              section: "{{ subnet_folder_data.section }}"
+        - name: Create subnet within folder
+          ansible.builtin.include_tasks: tasks/subnet.yml
+          vars:
+            name: "create subnet '{{ subnet_folder_data.cidr }}' within folder '{{ subnet_folder_data.folder }}'"
+            subnet: "{{ subnet_folder_data }}"
+
+    - name: Create entities again, no change
+      block:
+        - name: Create folder again, no change
+          ansible.builtin.include_tasks: tasks/folder.yml
+          vars:
+            name: "create folder '{{ subnet_folder_data.folder }}'"
+            folder:
+              name: "{{ subnet_folder_data.folder }}"
+              section: "{{ subnet_folder_data.section }}"
+        - name: Create subnet within folder again, no change
+          ansible.builtin.include_tasks: tasks/subnet.yml
+          vars:
+            name: "create subnet '{{ subnet_folder_data.cidr }}' within folder '{{ subnet_folder_data.folder }}'"
+            subnet: "{{ subnet_folder_data }}"
+
+    - name: Create subnet with folder and parent section
+      ansible.builtin.import_tasks: tasks/subnet.yml
+      vars:
+        name: "Try to setup subent '{{ subnet_folder_data.cidr }}' with parent and folder set"
+        fragment:
+          parent: 10.65.22.0/24
+        subnet: "{{ subnet_folder_data | combine(fragment) }}"
+      register: result
+      ignore_errors: True
+
+    - name: Delete entities
+      block:
+        - name: Delete subnet
+          ansible.builtin.include_tasks: tasks/subnet.yml
+          vars:
+            name: delete subnet '{{ subnet_folder_data.cidr }}' from folder '{{ subnet_folder_data.folder }}'
+            override:
+              state: absent
+            subnet: "{{ subnet_folder_data | combine(override) }}"
+        - name: Delete folder
+          ansible.builtin.include_tasks: tasks/folder.yml
+          vars:
+            name: delete folder '{{ subnet_folder_data.folder }}'
+            folder:
+              name: "{{ subnet_folder_data.folder }}"
+              section: "{{ subnet_folder_data.section }}"
+              state: absent

--- a/tests/test_playbooks/tasks/subnet.yml
+++ b/tests/test_playbooks/tasks/subnet.yml
@@ -15,6 +15,7 @@
     routing_domain: "{{ subnet.routing_domain | default(omit) }}"
     vrf: "{{ subnet.vrf | default(omit) }}"
     parent: "{{ subnet.parent | default(omit) }}"
+    folder: "{{ subnet.folder | default(omit) }}"
     nameserver: "{{ subnet.nameserver | default(omit) }}"
     show_as_name: "{{ subnet.show_as_name | default(omit) }}"
     permissions: "{{ subnet.permissions | default(omit) }}"

--- a/tests/test_playbooks/vars/subnet.yml
+++ b/tests/test_playbooks/vars/subnet.yml
@@ -21,3 +21,8 @@ subnet_parents:
   - cidr: 172.16.1.0/24
     section: "Customers"
     parent: 172.16.0.0/20
+
+subnet_folder_data:
+  cidr: 10.65.22.0/25
+  section: "Customers"
+  folder: "Example folder"


### PR DESCRIPTION
Our `subnet` module needs to be refactored due to splitting up folder
and subnet handling into two modules. For that reason we need to remove
`is_folder` and add `folder` parameter.
For resolving a folder name to its corresponding id we can use already
implemented methods.

/Resolves #104