### PR TITLE
Use myst-parser in favor of recommonmark

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ version = u''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'recommonmark',
+    'myst_parser',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx_antsibull_ext',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,5 @@ antsibull-changelog
 antsibull-docs>=1
 ansible-core
 sphinx-rtd-theme
-recommonmark
+myst-parser
 py


### PR DESCRIPTION
As `recommonmark` was phased out, we decided to use `myth-parser` instead, as also mentioned in https://github.com/readthedocs/recommonmark/issues/221.