### PR TITLE
Workaround for issues with phpIPAM 1.7.0 and above

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ install-deps:
 
 setup-phpipam: test-setup
 	docker-compose -f tests/docker/docker-compose.yml up -d
-	sh tests/docker/setup_database.sh
+	sh tests/docker/setup_phpipam.sh
 
 FORCE:
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,6 @@ install-deps:
 
 setup-phpipam: test-setup
 	docker-compose -f tests/docker/docker-compose.yml up -d
-	sleep 30
 	sh tests/docker/setup_database.sh
 
 FORCE:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,34 @@ The following dependencies have to be fulfiled by the Ansible controller.
 * ipaddress
 * phpypam>=1.0.0
 
+## Compatibility notice
+
+To ensure `phpipam-ansible-modules` work correctly with phpIPAM versions 1.7 and above, you need to modify the phpIPAM configuration to stringify API results. This is crucial because newer phpIPAM versions might return numerical values directly, which the Ansible modules might expect as strings.
+
+Here's how to implement the workaround:
+
+**1. Modify phpIPAM Configuration**
+
+You need to set the `api_stringify_results` variable to `true` in your phpIPAM configuration. This change should be made in the `config.php` file, which is typically located in the phpIPAM installation directory (e.g., `/var/www/html/phpipam/config.php` or `/var/www/phpipam/config.php`).
+
+Add or modify the following line in your `config.php` file:
+
+```
+<?php
+/*
+ * phpIPAM config.php
+ *
+ * ... existing configuration ...
+ */
+
+// Required for Ansible modules with phpIPAM v1.7 and above
+$api_stringify_results = true;
+
+/*
+ * ... rest of your configuration ...
+ */
+?>
+```
 ## Need help?
 
 If you’ve found any issues in this release please head over to github and open a bug so we can take a look.

--- a/tests/docker/docker-compose.yml
+++ b/tests/docker/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   phpipam:
     image: "phpipam/phpipam-www:${PHPIPAM_VERSION:-v1.4.4}"

--- a/tests/docker/setup_database.sh
+++ b/tests/docker/setup_database.sh
@@ -1,25 +1,51 @@
 #!/bin/bash
 
-if grep -iq podman <<< $(docker version 2> /dev/null) ; then
-  echo "Podman is installed"
+exec 10>&1
+exec > /dev/null 2>&1
+
+function info() {
+    echo "${@}" >&10
+}
+
+MYSQL_PING="mysqladmin ping -h ${DB_HOST:-127.0.0.1} -P ${DB_PORT:-3306} -u ${MYSQL_ROOT_USER:-root} -p${MYSQL_ROOT_PASSWORD:-rootpw}"
+
+if grep -qi podman <<< $(docker version 2> /dev/null) ; then
+  info "Podman is installed"
   DOCKER_CMD=$(which podman)
 fi
 
-while ! nc -z "${DB_HOST:-127.0.0.1}" "${DB_PORT:-3306}"; do
-  echo "Waiting for database connection..."
-  sleep 1
-done
+if "${DOCKER_CMD}" ps | grep -q phpipam_test_webserver && ! eval "${MYSQL_PING}" ; then
 
-echo "Database is up"
+    info -n "Waiting for database connection "
+    while ! eval "${MYSQL_PING}" ; do
+        info -n "."
+        sleep 1
+    done
+    info
+fi
 
-echo "Creating database ${DB_NAME:-phpipam}"
-${DOCKER_CMD} exec -ti phpipam_test_webserver sh -c 'mysql -h database -u phpipam -pphpipamadmin phpipam < /phpipam/db/SCHEMA.sql'
+info "Database is up"
 
-echo "Activating API"
-mysql -u phpipam -pphpipamadmin -h "${DB_HOST:-127.0.0.1}" phpipam --execute="UPDATE settings SET api=1 WHERE id=1;"
+if [[ $(mysqlshow -u root -prootpw -h 127.0.0.1 -P 3306 phpipam 2>/dev/null | wc -l) -eq 5 ]] ; then
 
-echo "Inserting API application"
-mysql -u phpipam -pphpipamadmin -h "${DB_HOST:-127.0.0.1}" phpipam --execute="INSERT INTO api (app_id, app_code, app_permissions, app_security, app_lock_wait) VALUES ('ansible','aAbBcCdDeEfF00112233445566778899',2,'ssl_token',0);"
+    info "Creating database ${DB_NAME:-phpipam}"
+    ${DOCKER_CMD} exec -t phpipam_test_webserver sh -c 'mysql -h database -u phpipam -pphpipamadmin phpipam < /phpipam/db/SCHEMA.sql' && ((init_result++))
 
-echo "Disable forced password reset"
-mysql -u phpipam -pphpipamadmin -h "${DB_HOST:-127.0.0.1}" phpipam --execute="UPDATE users SET passChange = 'No' WHERE username = 'Admin';"
+    info "Activating API"
+    mysql -u phpipam -pphpipamadmin -h "${DB_HOST:-127.0.0.1}" phpipam --execute="UPDATE settings SET api=1 WHERE id=1;" && ((init_result++))
+
+    info "Inserting API application"
+    mysql -u phpipam -pphpipamadmin -h "${DB_HOST:-127.0.0.1}" phpipam --execute="INSERT INTO api (app_id, app_code, app_permissions, app_security, app_lock_wait) VALUES ('ansible','aAbBcCdDeEfF00112233445566778899',2,'ssl_token',0);" && ((init_result++))
+
+    info "Disable forced password reset"
+    mysql -u phpipam -pphpipamadmin -h "${DB_HOST:-127.0.0.1}" phpipam --execute="UPDATE users SET passChange = 'No' WHERE username = 'Admin';" && ((init_result++))
+
+    [ "$init_result" -eq 4 ] && result=successful || result=failed
+
+else
+
+    info "Detabase already initiated" && exit 0
+
+fi
+
+info "Database initialisation $result"

--- a/tests/docker/setup_phpipam.sh
+++ b/tests/docker/setup_phpipam.sh
@@ -3,9 +3,6 @@
 exec 10>&1
 exec > /dev/null 2>&1
 
-# split version number into semvar parts
-read -r MAJOR MINOR PATCH <<<$(echo ${PHPIPAM_VERSION#v} | tr . " ")
-
 function info() {
     echo "${@}" >&10
 }
@@ -19,7 +16,7 @@ fi
 
 if "${DOCKER_CMD}" ps | grep -q phpipam_test_webserver && ! eval "${MYSQL_PING}" ; then
 
-    if [[ ${MINOR} -ge 7 ]] ; then
+    if [[ $(echo ${PHPIPAM_VERSION:-v1.4.4} | sed -E 's/v[0-9]?.([0-9]?).[0-9]?/\1/g') -ge 7 ]] ; then
         info "Running version 1.7.0 or above, patching config"
         ${DOCKER_CMD} exec -t phpipam_test_webserver sh -c 'sed -i "s/api_stringify_results = false/api_stringify_results = true/g" /phpipam/config.dist.php'
     fi

--- a/tests/docker/setup_phpipam.sh
+++ b/tests/docker/setup_phpipam.sh
@@ -3,6 +3,9 @@
 exec 10>&1
 exec > /dev/null 2>&1
 
+# split version number into semvar parts
+read -r MAJOR MINOR PATCH <<<$(echo ${PHPIPAM_VERSION#v} | tr . " ")
+
 function info() {
     echo "${@}" >&10
 }
@@ -15,6 +18,11 @@ if grep -qi podman <<< $(docker version 2> /dev/null) ; then
 fi
 
 if "${DOCKER_CMD}" ps | grep -q phpipam_test_webserver && ! eval "${MYSQL_PING}" ; then
+
+    if [[ ${MINOR} -ge 7 ]] ; then
+        info "Running version 1.7.0 or above, patching config"
+        ${DOCKER_CMD} exec -t phpipam_test_webserver sh -c 'sed -i "s/api_stringify_results = false/api_stringify_results = true/g" /phpipam/config.dist.php'
+    fi
 
     info -n "Waiting for database connection "
     while ! eval "${MYSQL_PING}" ; do
@@ -44,8 +52,8 @@ if [[ $(mysqlshow -u root -prootpw -h 127.0.0.1 -P 3306 phpipam 2>/dev/null | wc
 
 else
 
-    info "Detabase already initiated" && exit 0
+    info "Database already initiated" && exit 0
 
 fi
 
-info "Database initialisation $result"
+info "Database initialization $result"


### PR DESCRIPTION
As the results from phpIPAM API were changed, integers will result not in strings anymore. We need to work around this by setting a config variable to stringify API results.

As long as we do not be able to implement a permanent fix, by setting the backend version in an environment variable or in configuration we describe how to set stringifying via phpIPAM configuration.

/fixes 121