### PR TITLE
Fix resolving devices by defining the correct search key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ test-setup: | tests/test_playbooks/vars/server.yml install-deps install
 	test -f tests/test_playbooks/vars/server.yml
 
 test-all:
-	coverage run -m pytest -n 4 --forked -vv 'tests/test_crud.py::test_crud'
+	coverage run -m pytest -n 8 --forked -vv 'tests/test_crud.py::test_crud'
 
 test-%:
 	coverage run -m pytest --forked -vv 'tests/test_crud.py::test_case_crud' --testcase $*

--- a/changelogs/fragments/fix_device_resolution_in_modules.yml
+++ b/changelogs/fragments/fix_device_resolution_in_modules.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- fix resolution of device in address module - \#135

--- a/plugins/module_utils/phpipam_helper.py
+++ b/plugins/module_utils/phpipam_helper.py
@@ -294,6 +294,8 @@ class PhpipamAnsibleModule(AnsibleModule):
             result = self.find_device_type(self.phpipam_params[key])
         elif controller == 'tools/tags':
             result = self.find_by_key(controller=controller, value=self.phpipam_params[key], key='type')
+        elif controller == 'tools/devices':
+            result = self.find_by_key(controller=controller, value=self.phpipam_params[key], key='hostname')
         elif controller == 'vlan':
             result = self.find_vlan(self.phpipam_params[key], self.phpipam_params['routing_domain'])
         elif controller == 'vrf':

--- a/tests/test_playbooks/address_device_mapping.yml
+++ b/tests/test_playbooks/address_device_mapping.yml
@@ -1,0 +1,53 @@
+- name: Address and device module test
+  hosts: localhost
+  gather_facts: false
+  vars_files:
+    - vars/server.yml
+    - vars/address.yml
+    - vars/device.yml
+  vars:
+    address_device:
+      device: 'Test device'
+    address: '{{ base_address_data | combine(address_device) }}'
+  tasks:
+    - name: Create entities
+      tags: [create]
+      block:
+        - name: Create device
+          ansible.builtin.include_tasks: tasks/device.yml
+          vars:
+            step: create device
+            device: '{{ base_device_data }}'
+        - name: Create address
+          ansible.builtin.include_tasks: tasks/address.yml
+          vars:
+            step: create address
+    - name: Create entities again, no change
+      tags: [read]
+      block:
+        - name: Create device again, no change
+          ansible.builtin.include_tasks: tasks/device.yml
+          vars:
+            step: create device again, no change
+            device: '{{ base_device_data }}'
+        - name: Create address again, no change
+          ansible.builtin.include_tasks: tasks/address.yml
+          vars:
+            step: create address again, no change
+    - name: Delete entities
+      tags: [delete]
+      block:
+        - name: Delete device
+          ansible.builtin.include_tasks: tasks/device.yml
+          vars:
+            step: delete device
+            override:
+              state: absent
+            device: '{{ base_device_data | combine(override) }}'
+        - name: Delete address
+          ansible.builtin.include_tasks: tasks/address.yml
+          vars:
+            step: delete address
+            override:
+              state: absent
+            address: '{{ base_address_data | combine(override) }}'


### PR DESCRIPTION
When defining a device, for example, in the address module, it fails due to the wrong search key when calling `find_by_key` in `_resolve_entity`. 

Due to the fields needed for a device entity in phpIPAM API:

```
$ curl -sk -XGET -H "phpipam-token: ${PHPIPAM_TOKEN}" ${PHPIPAM_API_URL}/tools/devices/ | jq '.data[0] | {id: .id, hostname: .hostname, ip: .ip}'
{
  "id": "8",
  "hostname": "Test device",
  "ip": "192.2.0.222"
}
```

By introducing an extra case for controller `tools/devices` we can override the default search key with `hostname`.