### PR TITLE
device_type: remove duplicate description on .EXAMPLE

### DIFF
--- a/plugins/modules/device_type.py
+++ b/plugins/modules/device_type.py
@@ -50,7 +50,6 @@ EXAMPLES = '''
     server_url: "https://ipam.example.com"
     name: "USP"
     description: "universal power supply"
-    description:
     state: present
 
 - name: "Remove device type"


### PR DESCRIPTION
get yamllint warning/error (duplicate description key) when use ansible-sanity