### PR TITLE
ansible-test(sanity): validate-modules: fix parameter-list-no-elements

### DIFF
--- a/plugins/modules/device.py
+++ b/plugins/modules/device.py
@@ -53,6 +53,7 @@ options:
         description: List of sections where the device belongs to
         type: list
         required: false
+        elements: str
     rack:
         description:
             - Rack where the device belongs to.

--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -41,6 +41,7 @@ options:
         description: List of sections where the nameserver appears
         type: list
         required: false
+        elements: str
 extends_documentation_fragment:
     - codeaffen.phpipam.phpipam
     - codeaffen.phpipam.phpipam.entity_state

--- a/plugins/modules/nameserver.py
+++ b/plugins/modules/nameserver.py
@@ -41,10 +41,12 @@ options:
         description: List of IP addresses the namerserver can be reached on
         type: list
         required: false
+        elements: str
     sections:
         description: List of sections where the nameserver appears
         type: list
         required: false
+        elements: str
 extends_documentation_fragment:
     - codeaffen.phpipam.phpipam
     - codeaffen.phpipam.phpipam.entity_state

--- a/plugins/modules/vrf.py
+++ b/plugins/modules/vrf.py
@@ -45,6 +45,7 @@ options:
         description: List of sections where the nameserver appears
         type: list
         required: false
+        elements: str
 extends_documentation_fragment:
     - codeaffen.phpipam.phpipam
     - codeaffen.phpipam.phpipam.entity_state


### PR DESCRIPTION
device.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.sections: Argument defines type as list but elements is not defined for dictionary value @ data['options']['sections']
domain.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.sections: Argument defines type as list but elements is not defined for dictionary value @ data['options']['sections']
nameserver.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.addresses: Argument defines type as list but elements is not defined for dictionary value @ data['options']['addresses']
nameserver.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.sections: Argument defines type as list but elements is not defined for dictionary value @ data['options']['sections']
vrf.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.sections: Argument defines type as list but elements is not defined for dictionary value @ data['options']['sections']